### PR TITLE
更新 renderer.js

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -16576,7 +16576,7 @@ module.exports = function (e) {
     value: !0
   });
   const o = n(53);
-  t.UpstreamRemoteName = '上游', t.findUpstreamRemote = function (e, n) {
+  t.UpstreamRemoteName = 'upstream', t.findUpstreamRemote = function (e, n) {
     const r = n.find((e) => e.name === t.UpstreamRemoteName);
     return r ? o.repositoryMatchesRemote(e, r) ? r : null : null
   }


### PR DESCRIPTION
您好，我最近在使用汉化文件时发现了一个问题：

我的很多以前`Fork`的Git仓库中被添加了一个叫做“**上游**”的远程仓库。而GitHub Desktop默认给上游远程仓库的命名是“**upstream**”。最后检查发现是汉化文件中的一处修改造成的。

这个问题貌似从2.4.1版本的翻译中就已经存在了。虽然在使用上无伤大雅，但是初次发现这种情况时还是挺困扰的，而且没发现这个问题的时候使用命令行工具还是会习惯于去`merge`“**upstream**”仓库，使得命令行端和图形端不同步。所以我认为这里不需要汉化，遵从原始命名比较好。

![0](https://user-images.githubusercontent.com/47817993/80224347-256a1f80-867c-11ea-9240-10810e6714c4.png)

![1](https://user-images.githubusercontent.com/47817993/80224374-2f8c1e00-867c-11ea-8ab6-670640407a38.png)

![2](https://user-images.githubusercontent.com/47817993/80224392-34e96880-867c-11ea-8aa4-886486206dfe.png)

我自己试着修改了这一处翻译，改回了“**upstream**”。我不知道只改这一处对不对。但是改动后软件工作正常，没发现什么问题。
